### PR TITLE
Set up Heroku build and deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "server.js",
   "scripts": {
     "build": "webpack --watch --config webpack.config.js",
+    "postinstall": "webpack --config webpack.config.js",
+    "heroku": "heroku local web",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -30,16 +32,14 @@
   },
   "homepage": "https://github.com/thornecc/grouptodo#readme",
   "private": true,
-  "devDependencies": {
+  "dependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "express": "^4.16.2",
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
     "webpack": "^3.8.1"
-  },
-  "dependencies": {
-    "express": "^4.16.2"
   }
 }


### PR DESCRIPTION
* Run `webpack` build process on Heroku servers.
* Serve app at http://grouptodo.herokuapp.com/

I enabled auto deployment as well, so from now on all merges into master should deploy to the app automatically. We will have to ditch Heroku when we implement service workers, though, because Heroku's free tier doesn't support SSL/HTTPS which is mandatory for service workers.

Note that the app can be viewed at the URL above right now, but it will be broken until this PR is merged, since `bundle.js` is not being built on their servers at present.